### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,12 +87,12 @@ jobs:
       - # Add support for more platforms with QEMU (optional)
         # https://github.com/docker/setup-qemu-action
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.4.0
+        uses: docker/setup-qemu-action@v3.5.0
       - # https://github.com/docker/setup-buildx-action/issues/57#issuecomment-1059657292
         # https://github.com/docker/buildx/issues/136#issuecomment-550205439
         # docker buildx create --driver-opt env.http_proxy=$http_proxy --driver-opt env.https_proxy=$https_proxy --driver-opt '"env.no_proxy='$no_proxy'"'
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.9.0
+        uses: docker/setup-buildx-action@v3.10.0
         with:
           buildkitd-config: .github/buildkitd.toml
           driver-opts: |
@@ -118,7 +118,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5.6.1
+        uses: docker/metadata-action@v5.7.0
         with:
           images: |
             name=snowdreamtech/alpine,enable=true
@@ -140,7 +140,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build and push
-        uses: docker/build-push-action@v6.14.0
+        uses: docker/build-push-action@v6.15.0
         with:
           context: .
           build-args: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/metadata-action](https://github.com/docker/metadata-action)** published a new release **[v5.7.0](https://github.com/docker/metadata-action/releases/tag/v5.7.0)** on 2025-02-26T15:31:35Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.15.0](https://github.com/docker/build-push-action/releases/tag/v6.15.0)** on 2025-02-26T15:28:00Z
* **[docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)** published a new release **[v3.5.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.5.0)** on 2025-02-26T15:41:14Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.10.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.10.0)** on 2025-02-26T15:36:31Z
