### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/description.yml
+++ b/.github/workflows/description.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
             docker-images: false
             swap-storage: false      
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}
@@ -102,25 +102,25 @@ jobs:
             env.https_proxy=${{ env.http_proxy }}
             "env.no_proxy='${{ env.no_proxy}}'"
       - name: Login to DockerHub
-        uses: docker/login-action@v3.4.0
+        uses: docker/login-action@v3.6.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Login to Quay.io
-        uses: docker/login-action@v3.4.0
+        uses: docker/login-action@v3.6.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3.4.0
+        uses: docker/login-action@v3.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5.7.0
+        uses: docker/metadata-action@v5.8.0
         with:
           images: |
             name=snowdreamtech/alpine,enable=true

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/metadata-action](https://github.com/docker/metadata-action)** published a new release **[v5.8.0](https://github.com/docker/metadata-action/releases/tag/v5.8.0)** on 2025-08-01T09:18:47Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.6.0](https://github.com/docker/login-action/releases/tag/v3.6.0)** on 2025-09-29T10:34:04Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v5.0.0](https://github.com/actions/checkout/releases/tag/v5.0.0)** on 2025-08-11T12:39:13Z
